### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/shared/demo-server/server.js
+++ b/shared/demo-server/server.js
@@ -171,17 +171,11 @@ if (hasCerts) {
     logger.info(`  Bug reports:   POST https://${HOST}:${HTTPS_PORT}/api/bug-reports`);
     logger.info(`  Health check:  GET  https://${HOST}:${HTTPS_PORT}/health`);
     logger.info(`  Log level:     ${LOG_LEVEL}`);
-
-    // Note!! In a production server, you would NOT log the cert paths like this — this is just for demo purposes.
-    logger.info(`  TLS cert:      ${CERT_PATH}`);
-    logger.info(`  TLS key:       ${KEY_PATH}`);
     logger.info('═'.repeat(72));
   });
 } else {
   // ---- HTTP mode (no certs found) ----------------------------------------
   logger.warn('No TLS certificates found — starting in plain HTTP mode.');
-  logger.warn(`  Looked for cert: ${CERT_PATH}`);
-  logger.warn(`  Looked for key:  ${KEY_PATH}`);
   logger.warn('  See README.md for instructions on generating certs.');
 
   app.listen(HTTP_PORT, HOST, () => {


### PR DESCRIPTION
Potential fix for [https://github.com/ptarmiganlabs/help-button.qs/security/code-scanning/6](https://github.com/ptarmiganlabs/help-button.qs/security/code-scanning/6)

In general, to fix clear-text logging of sensitive information, avoid writing sensitive values (or anything derived from them) directly to logs. Either remove those log statements, or replace them with redacted/boolean metadata (e.g., “TLS certificate configured via environment variable”) that does not reveal secrets or detailed paths.

For this specific case, the best minimal-impact fix is:

- Stop logging the actual `CERT_PATH` and `KEY_PATH` values in both HTTPS and HTTP modes.
- Optionally replace them with generic messages that convey what happened (e.g., “No TLS certificates found — starting in plain HTTP mode. See README…”) without echoing the exact paths.
- Do not alter how `CERT_PATH` and `KEY_PATH` are computed or used to read the files; only change the log messages.

Concretely, in `shared/demo-server/server.js`:

- In the HTTPS branch (`if (hasCerts)`), delete the two `logger.info` lines that print `TLS cert:` and `TLS key:`. The preceding comment explicitly notes that this is not suitable for production, so removing them is consistent with that intent.
- In the HTTP branch (`else`), remove the two `logger.warn` lines that log `Looked for cert: ${CERT_PATH}` and `Looked for key:  ${KEY_PATH}`. The remaining warning and the README hint are sufficient for troubleshooting without exposing environment-derived paths.

No new imports, methods, or definitions are required; we are only editing/removing log statements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
